### PR TITLE
Secure cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "type": "module",
   "main": "server.js",

--- a/server.js
+++ b/server.js
@@ -63,7 +63,7 @@ app.post('/api/login', async (req, res) => {
   let password = req.body.password;
 
   if (password == process.env.PASSWORD) {
-    res.cookie('password', password, { maxAge: 900000 });
+    res.cookie('password', password, { maxAge: 900000, sameSite: 'none', secure: true });
 
     res.status(302)
       .header('Location', '/index.html')


### PR DESCRIPTION
In order to embed in iframes, `samesite` must be set to `none` on cookies (I guess)
Signed-off-by: jpaulsen <jpaulsen@lo3energy.com>